### PR TITLE
Coerce input text to character

### DIFF
--- a/R/replace_number.R
+++ b/R/replace_number.R
@@ -35,6 +35,8 @@
 #' }
 replace_number  <-
 function(text.var, num.paste = TRUE, remove = FALSE) {
+    
+    text.var <- as.character(text.var)
 
     if (remove) return(gsub("[0-9]", "", text.var))
 


### PR DESCRIPTION
This should fix issues that arose when you input a numeric vector with large values as `text.var`.
For example, if you called `replace_number("1000000")` you'd receive the output "nine hundred ninety nine thousand nine hundred ninety nine" but if you called `replace_number(1000000)` you receive the output "onee+six".